### PR TITLE
Add partition pump loop to partition_context

### DIFF
--- a/eventprocessorhost/partition_context.py
+++ b/eventprocessorhost/partition_context.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # -----------------------------------------------------------------------------------
-
+import asyncio
 import logging
 from eventprocessorhost.checkpoint import Checkpoint
 
@@ -10,7 +10,7 @@ class PartitionContext:
     """
     Encapsulates information related to an Event Hubs partition used by AbstractEventProcessor
     """
-    def __init__(self, host, partition_id, eh_path, consumer_group_name):
+    def __init__(self, host, partition_id, eh_path, consumer_group_name, pump_loop=None):
         self.host = host
         self.partition_id = partition_id
         self.eh_path = eh_path
@@ -18,6 +18,7 @@ class PartitionContext:
         self.offset = "-1"
         self.sequence_number = 0
         self.lease = None
+        self.pump_loop = pump_loop or asyncio.get_event_loop()
 
     def set_offset_and_sequence_number(self, event_data):
         """

--- a/eventprocessorhost/partition_pump.py
+++ b/eventprocessorhost/partition_pump.py
@@ -48,7 +48,8 @@ class PartitionPump():
         self.set_pump_status("Opening")
         self.partition_context = PartitionContext(self.host, self.lease.partition_id,
                                                   self.host.eh_config.client_address,
-                                                  self.host.eh_config.consumer_group)
+                                                  self.host.eh_config.consumer_group,
+                                                  self.loop)
         self.partition_context.lease = self.lease
         self.processor = self.host.event_processor(self.host.event_processor_params)
         try:


### PR DESCRIPTION
This gives the EventProcessor access to the partition_pump loop object. This way if
One desires to run synchronous code inside process_events_async one can utilize the
loop object to run the synchronous code using await context.pump_loop.run_in_executor(None, bla)