### PR TITLE
update connection string examples

### DIFF
--- a/examples/recv.py
+++ b/examples/recv.py
@@ -38,9 +38,9 @@ class MyReceiver(Receiver):
 
 try:
     ADDRESS = ("amqps://"
-               "<URL-encoded-SAS-policy>"
+               "<SAS-policy>"
                ":"
-               "<URL-encoded-SAS-key>"
+               "<SAS-key>"
                "@"
                "<mynamespace>.servicebus.windows.net"
                "/"

--- a/examples/recv_async.py
+++ b/examples/recv_async.py
@@ -37,9 +37,9 @@ async def pump(recv, count):
 
 try:
     ADDRESS = ("amqps://"
-               "<URL-encoded-SAS-policy>"
+               "<SAS-policy>"
                ":"
-               "<URL-encoded-SAS-key>"
+               "<SAS-key>"
                "@"
                "<mynamespace>.servicebus.windows.net"
                "/"

--- a/examples/send.py
+++ b/examples/send.py
@@ -15,9 +15,9 @@ logger = examples.get_logger(logging.INFO)
 
 try:
     ADDRESS = ("amqps://"
-               "<URL-encoded-SAS-policy>"
+               "<SAS-policy>"
                ":"
-               "<URL-encoded-SAS-key>"
+               "<SAS-key>"
                "@"
                "<mynamespace>.servicebus.windows.net"
                "/"

--- a/examples/send_async.py
+++ b/examples/send_async.py
@@ -22,9 +22,9 @@ async def send(snd, count):
 
 try:
     ADDRESS = ("amqps://"
-               "<URL-encoded-SAS-policy>"
+               "<SAS-policy>"
                ":"
-               "<URL-encoded-SAS-key>"
+               "<SAS-key>"
                "@"
                "<mynamespace>.servicebus.windows.net"
                "/"


### PR DESCRIPTION
Update connection string examples to reflect the correct format.

The connection string example should just be
```python
    ADDRESS = ("amqps://"
               "<SAS-policy>"
               ":"
               "<SAS-key>"
               "@"
               "<mynamespace>.servicebus.windows.net"
               "/"
               "myeventhub")
```
instead of saying <URL-encoded-SAS-policy> or <URL-encoded-SAS-key> because that typically means posting it in the Key=Value format. Also, if I run it through urlencode and then do a split and it has special characters, stuff like this happens:

```python
>>> from urllib.parse import urlencode
>>> encoded_key = urlencode({'SharedAccessKey': 'foo/bar+key='})
>>> print(encoded_key)
SharedAccessKey=foo%2Fbar%2Bkey%3D
>>> pre, key = encoded_key.split('=')
>>> print(key)
foo%2Fbar%2Bkey%3D
>>>
```