### PR TITLE
Fix syntax errors in iothub_recv.py

### DIFF
--- a/examples/iothub_recv.py
+++ b/examples/iothub_recv.py
@@ -10,9 +10,10 @@ from azure import eventhub
 from azure.eventhub import EventData, EventHubClient, Offset
 
 import logging
+import os
 logger = logging.getLogger('azure.eventhub')
 
-CONNSTR = os.environ['IOTHUB_CONNECTION_STR']
+iot_connection_str = os.environ['IOTHUB_CONNECTION_STR']
 
 client = EventHubClient.from_iothub_connection_string(iot_connection_str, debug=True)
 receiver = client.add_receiver("$default", "0", operation='/messages/events')


### PR DESCRIPTION
The `iothub_recv.py` as checked in had some syntax errors.  I've fixed up and done basic verification, at least up to the `get_eventhub_info()`, that everything works on Python 3.6 on Windows 10.