### PR TITLE
Update readme to reflect proper historical fork

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 Microsoft Azure SDK for Event Hubs
 ==================================
 
-This project has been moved to the `azure-sdk-for-python <https://github.com/Azure/azure-sdk-for-python/tree/eventhub_track1>`__ repository, under:
+This project has been moved to the `azure-sdk-for-python <https://github.com/Azure/azure-sdk-for-python/tree/release/eventhub-v1>`__ repository, under:
 
-`azure-sdk-for-python/sdk/eventhub/azure-eventhubs <https://github.com/Azure/azure-sdk-for-python/tree/eventhub_track1/sdk/eventhub/azure-eventhubs>`__.
+`azure-sdk-for-python/sdk/eventhub/azure-eventhubs <https://github.com/Azure/azure-sdk-for-python/tree/release/eventhub-v1/sdk/eventhub/azure-eventhubs>`__.
 
 This repository is no longer maintained.
 


### PR DESCRIPTION
There was back and forth about proper branch naming, with _track1 being the initial attempt.  After coalescing on -v1, need to update this doc accordingly to properly guide users.